### PR TITLE
Add loop to gogs admin create

### DIFF
--- a/cicd-template.yaml
+++ b/cicd-template.yaml
@@ -342,7 +342,7 @@ objects:
                 --form retype=$GOGS_PWD \
                 --form email=admin@gogs.com)
 
-              if [ $_RETURN == "200" || [ $_RETURN == "302" ]
+              if [ $_RETURN == "200" ] || [ $_RETURN == "302" ]
               then
                 echo "SUCCESS: Created gogs admin user"
                 break

--- a/cicd-template.yaml
+++ b/cicd-template.yaml
@@ -329,21 +329,34 @@ objects:
 
             oc rollout status dc gogs
 
-            _RETURN=$(curl -o /tmp/curl.log -sL --post302 -w "%{http_code}" http://$GOGS_SVC:3000/user/sign_up \
-              --form user_name=$GOGS_USER \
-              --form password=$GOGS_PWD \
-              --form retype=$GOGS_PWD \
-              --form email=admin@gogs.com)
-
-            sleep 5
-
-            if [ $_RETURN != "200" ] && [ $_RETURN != "302" ] ; then
-              echo "ERROR: Failed to create Gogs admin"
-              cat /tmp/curl.log
-              exit 255
-            fi
-
+            # Even though the rollout is complete gogs isn't always ready to create the admin user
             sleep 10
+
+            # Try 10 times to create the admin user. Fail after that.
+            for i in {1..10};
+            do
+
+              _RETURN=$(curl -o /tmp/curl.log -sL --post302 -w "%{http_code}" http://$GOGS_SVC:3000/user/sign_up \
+                --form user_name=$GOGS_USER \
+                --form password=$GOGS_PWD \
+                --form retype=$GOGS_PWD \
+                --form email=admin@gogs.com)
+
+              if [ $_RETURN == "200" || [ $_RETURN == "302" ]
+              then
+                echo "SUCCESS: Created gogs admin user"
+                break
+              elif [ $_RETURN != "200" ] && [ $_RETURN != "302" ] && [ $i == 10 ]; then
+                echo "ERROR: Failed to create Gogs admin"
+                cat /tmp/curl.log
+                exit 255
+              fi
+
+              # Sleep between each attempt
+              sleep 10
+
+            done
+
 
             cat <<EOF > /tmp/data.json
             {
@@ -386,6 +399,9 @@ objects:
               cat /tmp/curl.log
               exit 255
             fi
+
+            exit 0
+
           image: openshift/origin:v3.9.0
           name: cicd-demo-installer-job
           resources: {}


### PR DESCRIPTION
Add a loop to try multiple times to create the gogs admin. On average it appears to always go to the second try which totals about 20 seconds after the oc rollout status says gogs should be ready to go.