### PR TITLE
Update epel, jq, and pip package installation

### DIFF
--- a/devsecops-playbook.yml
+++ b/devsecops-playbook.yml
@@ -41,9 +41,9 @@
 
   roles:
    - install-oc
+   - install-epel
    - install-jq
    - install-pip
-   - install-epel
    - install-passlib
    - install-git
    - install-oscap

--- a/playbooks/roles/install-jq/tasks/main.yml
+++ b/playbooks/roles/install-jq/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 
 - name: Install jq command-line JSON processor
-  shell: "curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/bin/jq && chmod +x /usr/bin/jq"
+  yum:
+    name: jq
+    state: latest
   become: true
   when: install_tools

--- a/playbooks/roles/install-pip/tasks/pip.yml
+++ b/playbooks/roles/install-pip/tasks/pip.yml
@@ -1,21 +1,14 @@
 ---
 
-- name: Check Python pip exists
-  shell: /usr/bin/which pip &>/dev/null
-  register: rf_result
-  become: true
-  ignore_errors: yes
-
-- name: Download Python pip
-  get_url: url=https://bootstrap.pypa.io/get-pip.py
-           dest=/home/{{ ansible_user }}/get-pip.py
-  when:  rf_result.rc == 1  
-
 - name: Install Python pip
-  command: /usr/bin/python /home/{{ ansible_user }}/get-pip.py chdir=/home/{{ ansible_user }}
+  yum:
+    name: python2-pip
+    state: latest
   become: true
-  when: rf_result.rc == 1
+  when: install_tools
 
 - name: Upgrade Python pip
-  pip: name=pip state=present
+  pip: 
+    name: pip 
+    state: present
   become: true


### PR DESCRIPTION
jq and pip were being installed form URLs instead of as RPMs. By moving the epel repo installation up in the install order we can then use yum to install jq and pip. This makes the code cleaner and easier to understand.